### PR TITLE
Feat: Add Completion dataset type

### DIFF
--- a/src/axolotl/prompt_tokenizers.py
+++ b/src/axolotl/prompt_tokenizers.py
@@ -132,15 +132,15 @@ class CompletionPromptTokenizingStrategy(InstructionPromptTokenizingStrategy):
         )
 
     def tokenize_prompt(self, prompt):
-        text = self.parse_instruction_fields(prompt)
-        full_prompt = self._build_full_prompt(text)
+        instruction = self.parse_instruction_fields(prompt)
+        full_prompt = self._build_full_prompt(instruction)
         tokenized_full_prompt = self._tokenize(full_prompt)
 
         return tokenized_full_prompt
 
-    def _build_full_prompt(self, text):
+    def _build_full_prompt(self, instruction):
         return self.prompter.build_prompt(
-            text
+            instruction
         )
 
 

--- a/src/axolotl/prompt_tokenizers.py
+++ b/src/axolotl/prompt_tokenizers.py
@@ -125,6 +125,25 @@ class NomicGPT4AllPromptTokenizingStrategy(InstructionPromptTokenizingStrategy):
         )
 
 
+class CompletionPromptTokenizingStrategy(InstructionPromptTokenizingStrategy):
+    def parse_instruction_fields(self, prompt) -> (str):
+        return (
+            prompt["text"]
+        )
+
+    def tokenize_prompt(self, prompt):
+        text = self.parse_instruction_fields(prompt)
+        full_prompt = self._build_full_prompt(text)
+        tokenized_full_prompt = self._tokenize(full_prompt)
+
+        return tokenized_full_prompt
+
+    def _build_full_prompt(self, text):
+        return self.prompter.build_prompt(
+            text
+        )
+
+
 class ReflectionPromptTokenizingStrategy(PromptTokenizingStrategy):
     def parse_instruction_fields(self, prompt) -> (str, str, str, str, str):
         raise NotImplementedError

--- a/src/axolotl/prompters.py
+++ b/src/axolotl/prompters.py
@@ -38,9 +38,9 @@ class JeopardyPrompter(AlpacaPrompter):
 class CompletionPrompter(AlpacaPrompter):
     def build_prompt(
         self,
-        text: str
+        instruction: str
     ) -> str:
-        return text
+        return instruction
 
     def get_response(self, output: str) -> str:
         return output.strip()

--- a/src/axolotl/prompters.py
+++ b/src/axolotl/prompters.py
@@ -35,6 +35,17 @@ class JeopardyPrompter(AlpacaPrompter):
     prompt_input = "Below is a Jeopardy clue paired with input providing the category of the clue. Write a concise response that best answers tbe clue given the category.\n\n### Instruction:\n{instruction}\n\n### Input:\n{input}\n\n### Response:\n"
 
 
+class CompletionPrompter(AlpacaPrompter):
+    def build_prompt(
+        self,
+        text: str
+    ) -> str:
+        return text
+
+    def get_response(self, output: str) -> str:
+        return output.strip()
+
+
 class GPTeacherPrompter(AlpacaPrompter):
     ...
 

--- a/src/axolotl/utils/data.py
+++ b/src/axolotl/utils/data.py
@@ -11,13 +11,17 @@ from axolotl.prompt_tokenizers import (
     GPTeacherPromptTokenizingStrategy,
     OpenAssistantPromptTokenizingStrategy,
     AlpacaReflectionPTStrategy,
-    ShareGPTPromptTokenizingStrategy, JeopardyPromptTokenizingStrategy,
+    ShareGPTPromptTokenizingStrategy,
+    JeopardyPromptTokenizingStrategy,
+    CompletionPromptTokenizingStrategy,
 )
 from axolotl.prompters import (
     AlpacaPrompter,
     GPTeacherPrompter,
     ReflectAlpacaPrompter,
-    ShareGPTPrompter, JeopardyPrompter,
+    ShareGPTPrompter,
+    JeopardyPrompter,
+    CompletionPrompter,
 )
 
 
@@ -115,6 +119,15 @@ def load_prepare_datasets(tokenizer, cfg, default_dataset_prepared_path):
             elif d.type == "sharegpt":
                 ds_strategy = ShareGPTPromptTokenizingStrategy(
                     ShareGPTPrompter(), tokenizer, cfg.train_on_inputs, cfg.sequence_len
+                )
+                ds_wrapper = TokenizedPromptDataset(ds_strategy, ds["train"])
+                datasets.append(ds_wrapper)
+            elif d.type == "completion":
+                ds_strategy = CompletionPromptTokenizingStrategy(
+                    CompletionPrompter(),
+                    tokenizer,
+                    cfg.train_on_inputs,
+                    cfg.sequence_len,
                 )
                 ds_wrapper = TokenizedPromptDataset(ds_strategy, ds["train"])
                 datasets.append(ds_wrapper)


### PR DESCRIPTION
## Proposal

Train a completion model like the base llama before fine-tuning on a specific domain. I am testing this method for fine-tuning completion model on another low-resource language (to give it knowledge about the language) before fine-tuning using instruct types (into chat).

## Usage

```yaml
datasets:
  - path: data/text.jsonl
    type: completion
```

Data format: 

Row of `{"text": "..."}`

## Misc

- I tried to write less repetitive code while following your class format. This code can definitely be shorter. Some functions just return the input
- I did not apply formatter like `black`

## Results so far

On a 10k dataset, it does not perform quite well. It does manage to use answer in correct language, but nothing special. My training also failed several times, so I think the result is not conclusive yet.